### PR TITLE
New graph with metrics per video

### DIFF
--- a/pigletprep/src/app/MetricsPage/page.tsx
+++ b/pigletprep/src/app/MetricsPage/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 import React, { useEffect, useState } from 'react';
-import { motion, useMotionValue, useTransform, useSpring, animate } from 'framer-motion';
+// import { motion, useMotionValue, useTransform, useSpring, animate } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { useRouter } from 'next/navigation';
 import { IoHome } from "react-icons/io5";
 import ExportButton from '@/components/ExportButton';
@@ -15,88 +16,89 @@ import { Bar, Radar } from 'react-chartjs-2';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { NumberTicker } from '@/components/magicui/number-ticker';
+import axios from 'axios';
 
-interface AnimatedScoreProps {
-  value: number;
-  label: string;
-  color?: "green" | "blue" | "purple" | "orange";
-  delay?: number;
-  initialValue?: number;
-}
+// interface AnimatedScoreProps {
+//   value: number;
+//   label: string;
+//   color?: "green" | "blue" | "purple" | "orange";
+//   delay?: number;
+//   initialValue?: number;
+// }
 
-const AnimatedScore: React.FC<AnimatedScoreProps> = ({ value, label, color = "green", delay = 0, initialValue = 0 }) => {
-  const x = useMotionValue(initialValue); // Use initialValue prop
-  React.useEffect(() => {
-    animate(x, value, { duration: 2, delay: 1.5 });
-  }, [value, delay, x]);
+// const AnimatedScore: React.FC<AnimatedScoreProps> = ({ value, label, color = "green", delay = 0, initialValue = 0 }) => {
+//   const x = useMotionValue(initialValue); // Use initialValue prop
+//   React.useEffect(() => {
+//     animate(x, value, { duration: 2, delay: 1.5 });
+//   }, [value, delay, x]);
   
-  const number = useTransform(x, (v) => Number(v.toFixed(0)));
-  const springX = useSpring(x, { damping: 20 });
-  const dx = useTransform(springX, (v) => `${v / 100}px 1px`);
+//   const number = useTransform(x, (v) => Number(v.toFixed(0)));
+//   const springX = useSpring(x, { damping: 20 });
+//   const dx = useTransform(springX, (v) => `${v / 100}px 1px`);
 
-  const shadowColor = {
-    green: '#22c55e',
-    darkgreen: '#006400',
-    blue: '#3b82f6',
-    purple: '#8b5cf6',
-    orange: '#f97316'
-  }[color];
+//   const shadowColor = {
+//     green: '#22c55e',
+//     darkgreen: '#006400',
+//     blue: '#3b82f6',
+//     purple: '#8b5cf6',
+//     orange: '#f97316'
+//   }[color];
 
-  const bgColor = {
-    green: 'bg-green-800 hover:bg-green-900',
-    blue: 'bg-blue-500 hover:bg-blue-600',
-    purple: 'bg-purple-500 hover:bg-purple-600',
-    orange: 'bg-orange-500 hover:bg-orange-600'
-  }[color];
+//   const bgColor = {
+//     green: 'bg-green-800 hover:bg-green-900',
+//     blue: 'bg-blue-500 hover:bg-blue-600',
+//     purple: 'bg-purple-500 hover:bg-purple-600',
+//     orange: 'bg-orange-500 hover:bg-orange-600'
+//   }[color];
 
-  const boxShadow = color === 'green' 
-    ? `0 1px 1px -0.5px ${shadowColor}24,` +
-      `0 2px 2px -1px ${shadowColor}23,` +
-      `0 3px 3px -1.5px ${shadowColor}23,` +
-      `0 4px 4px -2px ${shadowColor}22,` +
-      `0 5px 5px -2.5px ${shadowColor}22,` +
-      `0 6px 6px -3px ${shadowColor}21,` +
-      `0 7px 7px -3.5px ${shadowColor}20,` +
-      `0 8px 8px -4px ${shadowColor}1d`
-    : `0 2.015px 1.612px -.34375px ${shadowColor}24,` +
-      `0 4.777px 3.821px -.6875px ${shadowColor}23,` +
-      `0 8.714px 6.971px -1.03125px ${shadowColor}23,` +
-      `0 14.487px 11.589px -1.375px ${shadowColor}22,` +
-      `0 23.395px 18.716px -1.71875px ${shadowColor}22,` +
-      `0 38.295px 30.636px -2.0625px ${shadowColor}21,` +
-      `0 65.942px 52.754px -2.40625px ${shadowColor}20,` +
-      `0 120px 96px -2.75px ${shadowColor}1d`;
+//   const boxShadow = color === 'green' 
+//     ? `0 1px 1px -0.5px ${shadowColor}24,` +
+//       `0 2px 2px -1px ${shadowColor}23,` +
+//       `0 3px 3px -1.5px ${shadowColor}23,` +
+//       `0 4px 4px -2px ${shadowColor}22,` +
+//       `0 5px 5px -2.5px ${shadowColor}22,` +
+//       `0 6px 6px -3px ${shadowColor}21,` +
+//       `0 7px 7px -3.5px ${shadowColor}20,` +
+//       `0 8px 8px -4px ${shadowColor}1d`
+//     : `0 2.015px 1.612px -.34375px ${shadowColor}24,` +
+//       `0 4.777px 3.821px -.6875px ${shadowColor}23,` +
+//       `0 8.714px 6.971px -1.03125px ${shadowColor}23,` +
+//       `0 14.487px 11.589px -1.375px ${shadowColor}22,` +
+//       `0 23.395px 18.716px -1.71875px ${shadowColor}22,` +
+//       `0 38.295px 30.636px -2.0625px ${shadowColor}21,` +
+//       `0 65.942px 52.754px -2.40625px ${shadowColor}20,` +
+//       `0 120px 96px -2.75px ${shadowColor}1d`;
 
-  return (
-    <div className="flex flex-col items-center mb-8 last:mb-0">
-      <motion.div
-        whileInView="visible"
-        viewport={{ once: true }}
-        initial={{ boxShadow: 'none' }}
-        animate={{ boxShadow }}
-        transition={{ delay: 1, duration: 1 }}
-        className={`w-[120px] h-[120px] rounded-full p-2 ${bgColor} relative flex items-center justify-center transition-colors`}
-      >
-        <svg viewBox="0 0 150 150" className="-rotate-90 w-full h-full" fill="none">
-          <motion.circle
-            cx="75"
-            cy="75"
-            r="70"
-            strokeWidth={'0.7rem'}
-            pathLength="0.99"
-            strokeDashoffset={'0px'}
-            className="stroke-lightpink"
-            strokeDasharray={dx}
-          />
-        </svg>
-        <motion.div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-2xl font-bold text-white">
-          {number}
-        </motion.div>
-      </motion.div>
-      <h3 className="text-base font-medium mt-2 text-black">{label}</h3>
-    </div>
-  );
-};
+//   return (
+//     <div className="flex flex-col items-center mb-8 last:mb-0">
+//       <motion.div
+//         whileInView="visible"
+//         viewport={{ once: true }}
+//         initial={{ boxShadow: 'none' }}
+//         animate={{ boxShadow }}
+//         transition={{ delay: 1, duration: 1 }}
+//         className={`w-[120px] h-[120px] rounded-full p-2 ${bgColor} relative flex items-center justify-center transition-colors`}
+//       >
+//         <svg viewBox="0 0 150 150" className="-rotate-90 w-full h-full" fill="none">
+//           <motion.circle
+//             cx="75"
+//             cy="75"
+//             r="70"
+//             strokeWidth={'0.7rem'}
+//             pathLength="0.99"
+//             strokeDashoffset={'0px'}
+//             className="stroke-lightpink"
+//             strokeDasharray={dx}
+//           />
+//         </svg>
+//         <motion.div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-2xl font-bold text-white">
+//           {number}
+//         </motion.div>
+//       </motion.div>
+//       <h3 className="text-base font-medium mt-2 text-black">{label}</h3>
+//     </div>
+//   );
+// };
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 ChartJS.register(RadialLinearScale, PointElement, LineElement, Filler, Tooltip, Legend);
@@ -126,12 +128,27 @@ const MetricsDashboard = () => {
     datasets: RadarDataset[];
   }
   
+  interface VideoStats {
+    videoTitle:          string
+    totalAttempts:       number
+    correctCount:        number
+    incorrectCount:      number
+    hintsUsed:           number
+    averageTimePerAttempt: number
+  }
+  interface ApiResponse {
+    success: boolean
+    data:    VideoStats[]
+  }
+
   const [chartData, setChartData] = useState<ChartData | null>(null); // State for chart data
   const [chartOptions, setChartOptions] = useState({}); // State for chart options
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [radarData, setRadarData] = useState<RadarData | null>(null);
   const [TotalSessions, setTotalSession] = useState<number>(0);
   const router = useRouter();
+  const [stats, setStats] = useState<VideoStats[]>([])
+  const [loading, setLoading] = useState(true)
 
 
   // Fetch data for the chart
@@ -312,6 +329,52 @@ const MetricsDashboard = () => {
   }, []);
 
 
+
+  useEffect(() => {
+    axios
+      .get<ApiResponse>('/api/metrics3')
+      .then(res => {
+        if (res.data.success) setStats(res.data.data)
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) return <p className="p-4">Loading…</p>
+
+  // X-axis labels
+  const labels = stats.map(s =>
+    s.videoTitle.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())
+  )
+
+  // Three parallel arrays
+  const correctData   = stats.map(s => s.correctCount)
+  const incorrectData = stats.map(s => s.incorrectCount)
+  const hintsData     = stats.map(s => s.hintsUsed)
+
+  const data = {
+    labels,
+    datasets: [
+      { label: 'Correct',    data: correctData,   backgroundColor: 'green'  },
+      { label: 'Incorrect',  data: incorrectData, backgroundColor: 'red'    },
+      { label: 'Hints Used', data: hintsData,     backgroundColor: 'orange' },
+    ],
+  }
+
+  const options = {
+    responsive: true,
+    plugins: {
+      // title:  { display: true, text: 'Per-Video Quiz Metrics' },
+      legend: { position: 'top' as const },
+    },
+    scales: {
+      x: { type: 'category' as const },
+      y: { beginAtZero: true },
+    },
+  }
+
+
+
   return (
     <div className="min-h-screen bg-beige p-8"> 
 
@@ -344,7 +407,9 @@ const MetricsDashboard = () => {
           </motion.div>
         </div>
         
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
+        {/* <div className="grid grid-cols-1 lg:grid-cols-4 gap-8"> */}
+        {/* <div className="flex justify- gap-8"> */}
+
           {/* Main Content (3/4 width) */}
           <div className="lg:col-span-3 space-y-10">
             {/* Total Users Card */}
@@ -371,17 +436,17 @@ const MetricsDashboard = () => {
               transition={{ duration: 1, delay: 1 }}
               className="bg-white rounded-2xl shadow-md border p-6"
             >
-              <h3 className="text-lg font-semibold mb-4 text-black">All Time Total Attempts Per Video</h3>
+              <h3 className="text-xl font-semibold mb-4 text-black">All Time Total Attempts Per Video</h3>
               {chartData ? (
                 <Bar data={chartData} options={chartOptions} />
               ) : (
                 <p>Loading chart...</p>
               )}
             </motion.div>
-          </div>
+          {/* </div> */}
 
           {/* Statistics Card (1/4 width) */}
-          <motion.div
+          {/* <motion.div
             initial={{ opacity: 0, scale: 0.95 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 1, delay: 1 }}
@@ -393,27 +458,40 @@ const MetricsDashboard = () => {
               <AnimatedScore value={90} label="Average Quiz Score" color="green" delay={0.4} initialValue={0} />
               <AnimatedScore value={100} label="Completion Rate" color="green" delay={0.6} initialValue={0} />
             </div>
-          </motion.div>
+          </motion.div> */}
         </div>
+
+
+        {/* Per-Video Quiz Metrics */}
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 1, delay: 1.5 }}
+          className="bg-white rounded-2xl shadow-md border p-6 mt-10 min-h-[400px]"
+          >
+            <h1 className="text-xl font-bold mb-4">Per-Video Quiz Metrics</h1>
+            <Bar data={data} options={options} />
+        </motion.div>
+
 
         {/* Radar Chart with Date Picker */}
         <motion.div
-              initial={{ opacity: 0, scale: 0.95 }}
-              animate={{ opacity: 1, scale: 1 }}
-              transition={{ duration: 1, delay: 1.5 }}
-              className="bg-white rounded-2xl shadow-md border p-6 mt-10 min-h-[400px]"
-            >
-              {/* <h1 className="text-2xl font-bold mb-4 text-black">Metrics Dashboard</h1> */}
-              <h2 className="text-xl font-semibold mb-2 text-black">Pick a Date to View Metrics</h2>
-              <DatePicker
-                selected={selectedDate}
-                onChange={handleDateChange}
-                dateFormat="yyyy-MM-dd"
-                className="border px-2 py-1 rounded mb-4"
-                placeholderText="Select a date"
-              />
-              {radarData ? <Radar data={radarData} /> : <p className="text-gray-500">No data available for selected date.</p>}
-          </motion.div>
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 1, delay: 1.5 }}
+            className="bg-white rounded-2xl shadow-md border p-6 mt-10 min-h-[400px]"
+          >
+            {/* <h1 className="text-2xl font-bold mb-4 text-black">Metrics Dashboard</h1> */}
+            <h2 className="text-xl font-semibold mb-2 text-black">Pick a Date to View Metrics</h2>
+            <DatePicker
+              selected={selectedDate}
+              onChange={handleDateChange}
+              dateFormat="yyyy-MM-dd"
+              className="border px-2 py-1 rounded mb-4"
+              placeholderText="Select a date"
+            />
+            {radarData ? <Radar data={radarData} /> : <p className="text-gray-500">No data available for selected date.</p>}
+        </motion.div>
 
 
       </div>

--- a/pigletprep/src/app/api/metrics/route.ts
+++ b/pigletprep/src/app/api/metrics/route.ts
@@ -1,3 +1,5 @@
+// This route handles the GET request to total attmpts per video and total sessions
+
 import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/mongodb';
 import QuizAttempt from '@/models/QuizAttempt';
@@ -31,7 +33,7 @@ export async function GET() {
                         $sort: { totalAttempts: -1 } // Optional: sort by popularity
                 },
         {
-                $limit: 4 // Optional: limit the number of video groups returned
+                $limit: 5 // Optional: limit the number of video groups returned
         }
     ]);
 

--- a/pigletprep/src/app/api/metrics2/by-date/route.ts
+++ b/pigletprep/src/app/api/metrics2/by-date/route.ts
@@ -1,34 +1,73 @@
-// app/api/metrics2/by-date/route.ts
-import { NextRequest, NextResponse } from 'next/server';
-import dbConnect from '@/lib/mongodb';
+// Route for radar chart data
+import { NextRequest, NextResponse } from 'next/server'
+import dbConnect from '@/lib/mongodb'
+import QuizAttempt from '@/models/QuizAttempt'
 
 export async function GET(req: NextRequest) {
-  const { searchParams } = new URL(req.url);
-  const date = searchParams.get('date');
-
-  if (!date || typeof date !== 'string') {
-    return NextResponse.json({ message: 'Date parameter is required' }, { status: 400 });
+  const { searchParams } = new URL(req.url)
+  const dateStr = searchParams.get('date')
+  if (!dateStr) {
+    return NextResponse.json(
+      { success: false, message: 'Date parameter is required' },
+      { status: 400 }
+    )
   }
 
-  try {
-    const mongoose = await dbConnect();
+  // Build the UTC range for that calendar day
+  const startDate = new Date(dateStr)
+  startDate.setUTCHours(0, 0, 0, 0)
+  const endDate = new Date(dateStr)
+  endDate.setUTCHours(23, 59, 59, 999)
 
-    const startDate = new Date(date);
-    startDate.setUTCHours(0, 0, 0, 0);
+  await dbConnect()
 
-    const endDate = new Date(date);
-    endDate.setUTCHours(23, 59, 59, 999);
+  // Fetch only attempts in that window
+  const attempts = await QuizAttempt.find({
+    timestamp: { $gte: startDate, $lte: endDate },
+  })
+    .lean()
 
-    const records = await mongoose.connection.collection('quizattempts').find({
-      timestamp: {
-        $gte: startDate,
-        $lte: endDate,
-      },
-    }).toArray();
+  // Group by cleanVideoId
+  const map = new Map<string, typeof attempts>()
+  attempts.forEach((at) => {
+    const raw   = at.videoId || ''
+    const clean = raw.split('/').pop()?.split('?')[0] || 'Unknown'
+    if (!map.has(clean)) map.set(clean, [])
+    map.get(clean)!.push(at)
+  })
 
-    return NextResponse.json({ success: true, records });
-  } catch (error) {
-    console.error('Error in API route:', error);
-    return NextResponse.json({ success: false, message: 'Server error' }, { status: 500 });
-  }
+  // Compute stats per video, excluding the placeholder
+  const stats = Array.from(map.entries())
+    .filter(([videoTitle]) => videoTitle !== 'dqT-UlYlg1s')
+    .map(([videoTitle, group]) => {
+      const totalAttempts = group.reduce((sum, a) => sum + (a.attempts || 0), 0)
+      const attemptsBeforeSuccess = group.reduce(
+        (sum, a) => sum + (a.metrics?.attemptsBeforeSuccess || 0),
+        0
+      )
+      const correctCount   = totalAttempts - attemptsBeforeSuccess
+      const incorrectCount = attemptsBeforeSuccess
+      const hintsUsed = group.reduce(
+        (sum, a) => sum + (a.metrics?.hints?.count || 0),
+        0
+      )
+      const totalTimeWeighted = group.reduce(
+        (sum, a) =>
+          sum + (a.metrics?.timePerAttempt ?? 0) * (a.attempts || 0),
+        0
+      )
+      const averageTimePerAttempt =
+        totalAttempts > 0 ? totalTimeWeighted / totalAttempts : 0
+
+      return {
+        videoTitle,
+        totalAttempts,
+        correctCount,
+        incorrectCount,
+        hintsUsed,
+        averageTimePerAttempt,
+      }
+    })
+
+  return NextResponse.json({ success: true, data: stats })
 }

--- a/pigletprep/src/app/api/metrics3/route.ts
+++ b/pigletprep/src/app/api/metrics3/route.ts
@@ -1,0 +1,55 @@
+// This route handles the GET request to fetch incorrect, correct, and hint used per video(grouped by videoId)
+import { NextResponse } from 'next/server'
+import dbConnect from '@/lib/mongodb'
+import QuizAttempt from '@/models/QuizAttempt'
+
+export async function GET() {
+  await dbConnect()
+
+  // Get all attempts
+  const allAttempts = await QuizAttempt.find().lean()
+
+  // Group by clean video filename
+  const map = new Map<string, typeof allAttempts>()
+  allAttempts.forEach(at => {
+    const raw   = at.videoId || ''
+    const clean = raw.split('/').pop()?.split('?')[0] || 'Unknown'
+    if (!map.has(clean)) map.set(clean, [])
+    map.get(clean)!.push(at)
+  })
+
+  // Compute stats per video, but first exclude "dqT-UlYlg1s" (this does not have a title)
+  const stats = Array.from(map.entries())
+    .filter(([videoTitle]) => videoTitle !== 'dqT-UlYlg1s')
+    .map(([videoTitle, attempts]) => {
+      const totalAttempts = attempts.reduce((sum, a) => sum + (a.attempts || 0), 0)
+      const attemptsBeforeSuccess = attempts.reduce(
+        (sum, a) => sum + (a.metrics?.attemptsBeforeSuccess || 0),
+        0
+      )
+      const correctCount   = totalAttempts - attemptsBeforeSuccess
+      const incorrectCount = attemptsBeforeSuccess
+      const hintsUsed = attempts.reduce(
+        (sum, a) => sum + (a.metrics?.hints?.count || 0),
+        0
+      )
+      const totalTimeWeighted = attempts.reduce(
+        (sum, a) =>
+          sum + (a.metrics?.timePerAttempt ?? 0) * (a.attempts || 0),
+        0
+      )
+      const averageTimePerAttempt =
+        totalAttempts > 0 ? totalTimeWeighted / totalAttempts : 0
+
+      return {
+        videoTitle,
+        totalAttempts,
+        correctCount,
+        incorrectCount,
+        hintsUsed,
+        averageTimePerAttempt,
+      }
+    })
+
+  return NextResponse.json({ success: true, data: stats })
+}

--- a/pigletprep/src/components/PinLockPage.tsx
+++ b/pigletprep/src/components/PinLockPage.tsx
@@ -12,11 +12,11 @@ interface PinLockPageProps {
 
 export default function PinLockPage({ onClose, onSuccess }: PinLockPageProps) {
   const [pin, setPin] = useState('');
-  const correctPin = process.env.NEXT_PUBLIC_METRICS_PAGE_KEY // Set your correct pin here
+  // const correctPin = process.env.NEXT_PUBLIC_METRICS_PAGE_KEY // Set your correct pin here
   const router = useRouter();
 
   const handlePinSubmit = useCallback(() => {
-    if (pin === correctPin) {
+    if (pin === process.env.NEXT_PUBLIC_METRICS_PAGE_KEY) {
       onSuccess();
       setTimeout(() => {
         router.push('/MetricsPage'); // Redirect to MetricsPage after animation

--- a/pigletprep/src/components/magicui/number-ticker.tsx
+++ b/pigletprep/src/components/magicui/number-ticker.tsx
@@ -17,7 +17,7 @@ export function NumberTicker({
   value,
   startValue = 0,
   direction = "up",
-  delay = 3,
+  delay = 0,
   className,
   decimalPlaces = 0,
   ...props


### PR DESCRIPTION
The total session is how many times a video plays. First graph represents total attempts per video from the date we created the db. Second graph compares different video metrics. Third graph filters metrics by date

- Since the timestamp is question-based, meaning it represents when the question pops up. There isn't a good, meaningful way to represent it on a graph. Also, we don't have a user-based system. So everything is represented as a sum